### PR TITLE
Put quotes around pdc command to account for PATH entries with spaces.

### DIFF
--- a/src/PDCTaskRunner.ts
+++ b/src/PDCTaskRunner.ts
@@ -33,7 +33,7 @@ export class PDCTaskRunner implements TaskRunner {
     const { strip, noCompress, verbose, quiet, skipUnknown } = this.options;
     const { sdkPath, sourcePath, gamePath } = await this.config.resolve();
 
-    const cmd = path.join(sdkPath, "bin", "pdc");
+    const cmd = quote(path.join(sdkPath, "bin", "pdc"));
     const args = [quote(sourcePath), quote(gamePath)];
 
     if (strip) {


### PR DESCRIPTION
The Playdate SDK might be in a path with spaces in it, so this extension needs to wrap the pdc command with quotes.