### PR TITLE
Increment build number, if desired, before compiling rather than after

### DIFF
--- a/src/pdc/PDCTaskRunner.ts
+++ b/src/pdc/PDCTaskRunner.ts
@@ -37,22 +37,20 @@ export class PDCTaskRunner implements TaskRunner {
     const pdcOptions = this.getPDCOptions();
     const pdcCommand = getPDCCommand(pdcOptions);
 
+    if (this.options.incrementBuildNumber) {
+      try {
+        const { sourcePath } = this.options;
+        const pdxInfo = await readPDXInfo(sourcePath);
+        incrementBuildNumber(pdxInfo);
+        await writePDXInfo(pdxInfo, sourcePath);
+      } catch (err) {
+        // noop
+      }
+    }
+
     onMessage("Compiling...");
     onMessage(`> ${pdcCommand}`);
     await exec(pdcCommand);
-
-    if (!this.options.incrementBuildNumber) {
-      return;
-    }
-
-    try {
-      const { sourcePath } = this.options;
-      const pdxInfo = await readPDXInfo(sourcePath);
-      incrementBuildNumber(pdxInfo);
-      await writePDXInfo(pdxInfo, sourcePath);
-    } catch (err) {
-      // noop
-    }
   }
 
   private getPDCOptions(): GetPDCCommandOptions {


### PR DESCRIPTION
Currently if `options.incrementBuildNumber` is set, the build task will increment the build number field in the `pdxinfo` file, but will only do so _after_ compiling with `pdc`. This causes the resulting build to embed metadata with an obsolete build number, and another rebuild is needed for the updated build number to be included. The game metadata can be retrieved via `playdate.metadata` in Lua (which is how I found this).

This small change moves the increment build number step so that it happens in the task runner _before_ the `pdc` compile step, and that way the resulting build will contain updated metadata from the `pdxinfo` file.