### PR TITLE
Fix incorrect resolution of sourcePath in ConfigurationResolver

### DIFF
--- a/src/core/ConfigurationResolver.ts
+++ b/src/core/ConfigurationResolver.ts
@@ -59,7 +59,7 @@ export class ConfigurationResolver {
 
     let sourcePath = sourcePathConfig;
     if (!sourcePath) {
-      sourcePath = path.resolve(workspaceRoot, "source");
+      sourcePath = "source";
     }
     sourcePath = toAbsolute(workspaceRoot, sourcePath);
 


### PR DESCRIPTION
The `sourcePath` was being resolved using `path.resolve(workspaceRoot, "source")` when it was missing, and then immediately passed to `toAbsolute(workspaceRoot, sourcePath)`. Since `path.resolve` returns an absolute path, applying `toAbsolute` on top of it was redundant and potentially incorrect if `toAbsolute` expects a relative path from the workspace root.

This fix ensures that when `sourcePath` is missing, we use a relative path ("source") which is then correctly resolved to an absolute path via `toAbsolute(workspaceRoot, sourcePath)`.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.